### PR TITLE
Check autogenerated broker ID isn't blank

### DIFF
--- a/kafka-kubernetes-start.sh
+++ b/kafka-kubernetes-start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+
 if [[ -z "${KAFKA_ADVERTISED_HOST_NAME// }" ]] ; then
 	echo "KAFKA_ADVERTISED_HOST_NAME NOT DEFINED OR INVALID '$KAFKA_ADVERTISED_HOST_NAME' !!!"
 	exit 1
@@ -12,6 +13,10 @@ if [[ -z "$KAFKA_BROKER_ID" ]]; then
 	fi
     echo "Generate Kafka Broker ID: for $KUBERNETS_UID"
 	ID=`$KAFKA_HOME/bin/kafka-run-class.sh kafka.admin.AutoExpandCommand --zookeeper=$KAFKA_ZOOKEEPER_CONNECT -broker=$KUBERNETS_UID -mode=generate`
+	if [[ -z "$ID" ]]; then
+		echo "Got empty broker ID from kafka.admin.AutoExpandCommand; not starting!"
+		exit 1
+	fi
 	echo "Use broker ID: $ID"
 	export KAFKA_BROKER_ID=$ID
 fi


### PR DESCRIPTION
Hello there,

I've been troubleshooting a problem on my cluster and discovered that in some circumstances `kafka.admin.AutoExpandCommand` does not return a broker ID.  This empty ID is then passed to Kafka upon startup.

I've added a test in `kafka-kubernetes-start.sh` so that we abort rather than starting up Kafka with an empty ID.

Cheers,
Alex
