### PR TITLE
Changed wurstmeister kafka version to 0.10.0.1 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wurstmeister/kafka:0.10.0.0
+FROM wurstmeister/kafka:0.10.0.1
 
 MAINTAINER CloudTrackInc
 


### PR DESCRIPTION
There's a newer tag on the version of kafka used (i.e. https://github.com/wurstmeister/kafka-docker). The newer version includes certain bug fixes such as https://github.com/wurstmeister/kafka-docker/commit/2857d50e073b4bdb86e740093a418e1f0b338edd that would be helpful to have
