### PR TITLE
Update for Kafka 0.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     compile 'org.scala-lang:scala-library:2.11.7'
     compile 'com.101tec:zkclient:0.7'
-    compile 'org.apache.kafka:kafka_2.11:0.9.0.1'
+    compile 'org.apache.kafka:kafka_2.11:0.10.0.1'
     compile 'org.scala-lang:scala-parser-combinators:2.11.0-M4'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }


### PR DESCRIPTION
The Dockerfile FROM had been updated but the auto expand code was no longer compatible.

I copied, almost verbatim, the `generateAssignment` function from the ReassignPartitionsCommand. The only change I made was to use a sequence of strings for the topic list instead of a topics-to-move style JSON string.

Testing on my POC cluster works as expected.
